### PR TITLE
[TEAM-498] Use self-hosted GitHub runners for actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     strategy:
       matrix:


### PR DESCRIPTION
Beep-boop! This is automatic pull-request to update github actions runners and explicitly use self-hosted.
Ask @Romanavr in Slack if you have questions